### PR TITLE
[16.0][IMP] shopinvader_api_customer_price: support batch _get_price

### DIFF
--- a/shopinvader_api_customer_price/schemas/product.py
+++ b/shopinvader_api_customer_price/schemas/product.py
@@ -13,4 +13,4 @@ class ProductPrice(StrictExtendableBaseModel):
 
     @classmethod
     def from_products(cls, records, pricelist=None):
-        return {rec.id: rec._get_price(pricelist=pricelist) for rec in records}
+        return records._get_price(pricelist=pricelist)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,3 +8,5 @@ vcrpy-unittest
 unittest2 # For shopinvader test_controller, which inherits component
 odoo-test-helper
 httpx  # For FastAPI tests
+
+odoo-addon-product_get_price_helper @ git+https://github.com/OCA/product-attribute@refs/pull/1954/head#subdirectory=setup/product_get_price_helper


### PR DESCRIPTION
This PR updates the `shopinvader_api_customer_price` module to support the new batch computation logic introduced in `_get_price`.

### Depends on:
https://github.com/OCA/product-attribute/pull/1954

### Notes: 
Because the `shopinvader_api_customer_price` module has not been merged yet, this PR will be temporarily kept internal and added directly to the project.